### PR TITLE
pmd_test demo

### DIFF
--- a/tools/pmd_test.bzl
+++ b/tools/pmd_test.bzl
@@ -7,38 +7,71 @@ def _impl(ctx):
         fail("Expecting a single java library")
 
     src_jar = lib.source_jars[0]
-    full_compile_jars = ":".join([f.path for f in lib.full_compile_jars.to_list()])
+    jar_deps = lib.full_compile_jars
+    full_compile_jars = ":".join([f.short_path for f in jar_deps.to_list()])
 
     # Presumably this needs to be updated to actually run the resulting shell script.
-    cmd = "@//tools:pmd"
 
-    args = [
-        cmd,
+    pmd_exe_file = ctx.attr._pmd[DefaultInfo].files_to_run.executable
+    ruleset = ctx.file.ruleset
+    pmd_cmd_args = [
+        pmd_exe_file.short_path,
         "-f text",
-        "-R pmd-ruleset.xml",
+        "-R {}".format(ruleset.short_path),
         "-d {}".format(src_jar.short_path),
-	"-auxclasspath {}".format(full_compile_jars),
+        "-auxclasspath {}".format(full_compile_jars),
     ]
-    argline = " ".join(args)
+    pmd_cmd = " ".join(pmd_cmd_args)
+    script = [
+        "#!/usr/bin/env bash",
+        "set -o errexit",
+        "set -o xtrace",
+        pmd_cmd,
+    ]
 
-    script = '\n'.join([
-        argline,
-    ])
-    print(script)
+    script_content = "\n".join(script)
+    print(script_content)
 
     # Write the file, it is executed by 'bazel test'.
+    test_file = ctx.actions.declare_file(ctx.attr.name)
     ctx.actions.write(
-        output = ctx.outputs.executable,
-        content = script,
+        output = test_file,
+        content = script_content,
+        is_executable = True,
     )
 
-    runfiles = ctx.runfiles(files=ctx.files.lib)
-    return [DefaultInfo(runfiles=runfiles)]
+    # Ensure everything that is needed to run PMD is in the runfiles tree:
+    pmd_runfiles = ctx.attr._pmd[DefaultInfo].data_runfiles.files
+    runfiles_jar_deps = depset(transitive = [
+        # Create a new depset w/ .to_list() to prevent a Java exception from being thrown in
+        # bazel 0.29.1 when combining depsets with different orders (in runfiles contruction).
+        depset(direct = jar_deps.to_list()),
+        pmd_runfiles,
+    ])
+    exe_runfile_deps = [ruleset, src_jar]
+    runfiles = ctx.runfiles(
+        transitive_files = runfiles_jar_deps,
+        files = exe_runfile_deps,
+    )
+    return [DefaultInfo(executable = test_file, runfiles = runfiles)]
 
 pmd_test = rule(
     implementation = _impl,
     attrs = {
-        "lib": attr.label(mandatory=True, allow_single_file=True),
+        "lib": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            providers = [JavaInfo],
+        ),
+        "ruleset": attr.label(
+            allow_single_file = True,
+            default = "@//tools:src/main/resources/pmd-ruleset.xml",
+        ),
+        "_pmd": attr.label(
+            executable = True,
+            cfg = "host",
+            default = Label("@//tools:pmd"),
+        ),
     },
     test = True,
 )


### PR DESCRIPTION
I just happened to be writing a bazel test rule for kubernetes kustomize bundles and decided to give this a shot. I can't speak for the right way / the way bazel developers currently think things should go, but this seems to work.

An alternative that might work and be simpler: a macro that 1) uses a genrule to write a small shell script, 2) a sh_test rule that has a data = [ "the pmd tool", "the srcjar", "the binary jar", "the ruleset" ] and a src = the output of the genrule. As everything to run the pmd tool is in the data deps of the sh_test, it should be available in the runfiles tree (which is half of this test rule's code, it seems).

Also note that there might be simpler ways to do this with a rule, even. I've only done a single test rule w/ a smattering of other rule types. 